### PR TITLE
Fixed media URLs

### DIFF
--- a/py8chan/file.py
+++ b/py8chan/file.py
@@ -97,9 +97,14 @@ class File(object):
 
     @property
     def thumbnail_fname(self):
-        return '%s.jpg' % (
-            self._data['tim']
-        )
+        if self._data['ext'] != '.png':
+            return '%s.jpg' % (
+                self._data['tim'],
+            )
+        else:
+            return '%s.png' % (
+                self._data['tim'],
+            )
 
     @property
     def thumbnail_url(self):

--- a/py8chan/file.py
+++ b/py8chan/file.py
@@ -15,7 +15,8 @@ class File(object):
     Attributes:
         file_md5 (string): MD5 hash of the file attached to this post.
         file_md5_hex (string): Hex-encoded MD5 hash of the file attached to this post.
-        filename (string): Original name of the file attached to this post.
+        filename_original (string): Original name of the file attached to this post.
+        filename (string): Filename of the file attached to this post.
         file_url (string): URL of the file attached to this post.
         file_extension (string): Extension of the file attached to this post. Eg: ``png``, ``webm``, etc.
         file_size (int): Size of the file attached to this post.
@@ -43,6 +44,13 @@ class File(object):
     @property
     def file_md5_hex(self):
         return hexlify(self.file_md5).decode('ascii')
+
+    @property
+    def filename_original(self):
+        return '%s%s' % (
+            self._data['filename'],
+            self._data['ext']
+        )
 
     @property
     def filename(self):
@@ -89,7 +97,7 @@ class File(object):
 
     @property
     def thumbnail_fname(self):
-        return '%ss.jpg' % (
+        return '%s.jpg' % (
             self._data['tim']
         )
 
@@ -97,7 +105,8 @@ class File(object):
     def thumbnail_url(self):
         board = self._post._thread._board
         return self._url.thumb_url(
-            self._data['tim']
+            self._data['tim'],
+            self._data['ext']
         )
 
     def file_request(self):

--- a/py8chan/url.py
+++ b/py8chan/url.py
@@ -28,7 +28,7 @@ class Url(object):
         DOMAIN = {
             'api': self._protocol + self._site_url,   # API subdomain
             'boards': self._protocol + self._site_url, # HTML subdomain
-            'file': self._protocol + self._site_url,  # file (image) host
+            'file': self._protocol + "media." + self._site_url,  # file (image) host
             'static': self._protocol + self._site_url + "/static" # static host
         }
         
@@ -43,8 +43,8 @@ class Url(object):
                 'thread': DOMAIN['boards'] + '/{board}/res/{thread_id}.html'
             },
             'data': {
-                'file': DOMAIN['file'] + '/{board}/src/{tim}{ext}',
-                'thumbs': DOMAIN['file'] + '/{board}/thumb/{tim}.jpg',
+                'file': DOMAIN['file'] + '/file_store/{tim}{ext}',
+                'thumbs': DOMAIN['file'] + '/file_store/thumb/{tim}.jpg',
                 'static': DOMAIN['static'] + '/{item}'
             }
         }

--- a/py8chan/url.py
+++ b/py8chan/url.py
@@ -19,8 +19,10 @@ class Url(object):
         # List (JSON) - http://8ch.net/newspaper/threads.json
         # Catalog (JSON) - http://8ch.net/newspaper/catalog.json
         #
-        # Image - https://8ch.net/newspaper/src/1421068790600.jpg
-        # Thumb - https://8ch.net/newspaper/thumb/1421068790600.jpg
+        # Image (old) - https://8ch.net/newspaper/src/1421068790600.jpg
+        # Thumb (old) - https://8ch.net/newspaper/thumb/1421068790600.jpg
+        # Image (new) - https://media.8ch.net/file_store/bf2f563fe4394ee60e5288b1193c87e40c54f3fb57894db3b141b88b9e79ca7c.jpg
+        # Thumb (new) - https://media.8ch.net/file_store/thumb/bf2f563fe4394ee60e5288b1193c87e40c54f3fb57894db3b141b88b9e79ca7c.jpg
         #
         # Static - http://8ch.net/static/blank.gif
         
@@ -44,7 +46,9 @@ class Url(object):
             },
             'data': {
                 'file': DOMAIN['file'] + '/file_store/{tim}{ext}',
-                'thumbs': DOMAIN['file'] + '/file_store/thumb/{tim}.jpg',
+                'thumbs': DOMAIN['file'] + '/file_store/thumb/{tim}{ext}',
+                'old_file': DOMAIN['file'] + '/{board}/src/{tim}{ext}',
+                'old_thumbs': DOMAIN['file'] + '/{board}/thumb/{tim}.jpg',
                 'static': DOMAIN['static'] + '/{item}'
             }
         }
@@ -107,18 +111,37 @@ class Url(object):
     
     # generate file URL
     def file_url(self, tim, ext):
-        return self.URL['data']['file'].format(
-            board=self._board,
-            tim=tim,
-            ext=ext
-            )
-    
+        # old or new file URL
+        if len(tim) == 13:
+            return self.URL['data']['old_file'].format(
+                board=self._board,
+                tim=tim
+                ext=ext
+                )
+        else:
+            return self.URL['data']['file'].format(
+                tim=tim
+                ext=ext
+                )
+
     # generate thumb URL
-    def thumb_url(self, tim):
-        return self.URL['data']['thumbs'].format(
-            board=self._board,
-            tim=tim
-            )
+    def thumb_url(self, tim, ext):
+        # old or new file URL
+        if len(tim) == 13:
+            return self.URL['data']['old_thumbs'].format(
+                board=self._board,
+                tim=tim
+                )
+        else:
+            # PNGs are not converted to JPGs
+            thumb_ext = '.jpg'
+            if ext == '.png':
+                thumb_ext = '.png'
+
+            return self.URL['data']['thumbs'].format(
+                tim=tim
+                ext=thumb_ext
+                )
     
     # return entire URL dictionary
     @property

--- a/py8chan/url.py
+++ b/py8chan/url.py
@@ -115,12 +115,12 @@ class Url(object):
         if len(tim) == 13:
             return self.URL['data']['old_file'].format(
                 board=self._board,
-                tim=tim
+                tim=tim,
                 ext=ext
                 )
         else:
             return self.URL['data']['file'].format(
-                tim=tim
+                tim=tim,
                 ext=ext
                 )
 
@@ -139,7 +139,7 @@ class Url(object):
                 thumb_ext = '.png'
 
             return self.URL['data']['thumbs'].format(
-                tim=tim
+                tim=tim,
                 ext=thumb_ext
                 )
     


### PR DESCRIPTION
8ch.net made some changes to files URLs.

Old files did have a 13 caraters long `tim` and were using the format `https://media.8ch.net/{board}/src/{tim}{ext}`. This changed to `https://media.8ch.net/file_store/{tim}{ext}` with a way longer `tim` now.
Same thing with thumbnails: `https://media.8ch.net/{board}/thumb/{tim}{ext}` to `https://media.8ch.net/file_store/thumb/{tim}.jpg` (note that .png files are being kept in .png).

I also added `filename_original` _"back"_ and added the subdomain `media.` for files.
