### PR TITLE
embed & minor fixes, resolves #1

### DIFF
--- a/py8chan/board.py
+++ b/py8chan/board.py
@@ -106,7 +106,7 @@ class Board(object):
         self._requests_session.headers['User-Agent'] = 'py-8chan/%s' % __version__
 
         self._thread_cache = {}
-        
+
         # 8chan catalog information contained in API request
         self._uri = self._get_metadata('uri')
         self._title = self._get_metadata('title')
@@ -295,7 +295,7 @@ class Board(object):
     @property
     def index(self):
         return self._indexed
-    
+
     @property
     def is_worksafe(self):
         return self._sfw
@@ -335,7 +335,7 @@ class Board(object):
     @property
     def daily_users(self):
         return self._ppd
-    
+
     @property
     def https(self):
         return self._https

--- a/py8chan/file.py
+++ b/py8chan/file.py
@@ -29,7 +29,7 @@ class File(object):
         thumbnail_fname (string): Filename of the thumbnail attached to this post.
         thumbnail_url (string): URL of the thumbnail attached to this post.
     """
-    
+
     def __init__(self, post, data):
         self._post = post
         self._data = data
@@ -42,7 +42,7 @@ class File(object):
         # More info: http://stackoverflow.com/a/16033232
         # returns a bytestring
         return b64decode(self._data['md5'])
-        
+
     @property
     def file_md5_hex(self):
         return hexlify(self.file_md5).decode('ascii')
@@ -117,11 +117,11 @@ class File(object):
         )
 
     def file_request(self):
-        return self._thread._board._requests_session.get(self.file_url)
+        return self._post._thread._board._requests_session.get(self.file_url)
 
     def thumbnail_request(self):
-        return self._thread._board._requests_session.get(self.thumbnail_url)
-        
+        return self._post._thread._board._requests_session.get(self.thumbnail_url)
+
     def __repr__(self):
         return '<File %s from Post /%s/%i#%i>' % (
             self.filename,

--- a/py8chan/thread.py
+++ b/py8chan/thread.py
@@ -250,7 +250,7 @@ class Thread(object):
     @property
     def semantic_url(self):
         raise AttributeError( "'py8chan.Thread' object has no attribute 'semantic_url'" )
-    
+
     # 8chan/vichan does not use semantic slugs
     @property
     def semantic_slug(self):

--- a/py8chan/url.py
+++ b/py8chan/url.py
@@ -53,7 +53,7 @@ class Url(object):
                 'static': DOMAIN['static'] + '/{item}'
             }
         }
-        
+
         # API Listings
         LISTING = {
             'board_list': DOMAIN['api'] + '/boards.json',
@@ -61,55 +61,55 @@ class Url(object):
             'archived_thread_list': None,          # not used by 8chan/vichan
             'catalog': DOMAIN['api'] + '/{board}/catalog.json'
         }
-        
+
         # combine all dictionaries into self.URL dictionary
         self.URL = TEMPLATE
         self.URL.update({'domain': DOMAIN})
         self.URL.update({'listing': LISTING})
-    
+
     # generate boards listing URL
     def board_list(self):
         return self.URL['listing']['board_list']
-    
+
     # generate board page URL
     def page_url(self, page):
         return self.URL['api']['board'].format(
             board=self._board,
             page=page
             )
-    
+
     # generate catalog URL
     def catalog(self):
         return self.URL['listing']['catalog'].format(
             board=self._board
             )
-    
+
     # generate threads listing URL
     def thread_list(self):
         return self.URL['listing']['thread_list'].format(
             board=self._board
             )
-    
+
     # 8chan/vichan does not implement archives as far as we know.
     # must be enabled when BASC_py4chan begins to use this feature,
     # Maybe raise an AttributeError? Maybe set URL class to properties?
     #	def archived_thread_list():
     #		return None
-    
+
     # generate API thread URL
     def thread_api_url(self, thread_id):
         return self.URL['api']['thread'].format(
             board=self._board,
             thread_id=thread_id
             )
-    
+
     # generate HTTP thread URL
     def thread_url(self, thread_id):
         return self.URL['http']['thread'].format(
             board=self._board,
             thread_id=thread_id
             )
-    
+
     # generate file URL
     def file_url(self, tim, ext):
         # new or old file URL
@@ -143,7 +143,7 @@ class Url(object):
                 board=self._board,
                 tim=tim
                 )
-    
+
     # return entire URL dictionary
     @property
     def site_urls(self):

--- a/py8chan/util.py
+++ b/py8chan/util.py
@@ -25,4 +25,5 @@ def clean_comment_body(body):
     body = body.replace('<br>', '\n')
     body = body.replace('<p class="body-line ltr ">', '\n')
     body = re.sub(r'<.+?>', '', body)
+    body = body.strip()
     return body


### PR DESCRIPTION
## EMBED Method
Added embed property to post, None if no embed. Used regex to parse the url.
```py
>>> post.embed_url
'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
```
Embed key on api only contained embed's url and the thumbnail url.
Api didn't provide any data about the thumbnail (size,width etc) and there wasn't much useful data besides that so i didn't create class for embed, and didn't use the File class to create an thumbnail object either.

### FIXES
Accessing the session like this:
```py
    def file_request(self):
        return self._thread._board._requests_session.get(self.file_url)
```
Was throwing this error:
```
py8chan/file.py:120:15: E1101: Instance of 'File' has no '_thread' member (no-member)
```
So replaced with `self._post._thread` instead.


Replacing <p with \n like this:
https://github.com/bibanon/py8chan/blob/bc498f3da434538676172e4b6f4413a0b105639d/py8chan/util.py#L26
was adding a newline beginning to texts:
```py
>>> p1.text_comment
'\nthe thread comment'
>>> p2.text_comment
'\n>>104493\nembed reply'
>>> p3.text_comment
'\nnow another post with an image'
```
Used .strip() to get rid of that.

